### PR TITLE
chatspace 自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,40 +1,44 @@
 $(function(){ 
+  
   function buildHTML(message){
    if ( message.image ) {
      var html =
-      `<div class="upper">
-        <div class="sender">
-          ${message.user_name}
+      `<div class="message" data-message-id=${message.id}>
+        <div class="upper">
+          <div class="sender">
+            ${message.user_name}
+          </div>
+          <div class="date">
+            ${message.created_at}
+          </div>
         </div>
-        <div class="date">
-          ${message.created_at}
-        </div>
-      </div>
-      <div class="message">
-        <p class="lower-message__content">
-          ${message.content}
-        </p>
-        <img src=${message.image}>
-      </div>`
-     return html;
+        <div class="message-detail">
+          <p class="lower-message__content">
+            ${message.content}
+          </p>
+          <img src=${message.image}>
+        </div>`
+      return html;
    } else {
      var html =
-      `<div class="upper">
-        <div class="sender">
-          ${message.user_name}
+      `<div class="message" data-message-id=${message.id}>
+        <div class="upper">
+          <div class="sender">
+            ${message.user_name}
+          </div>
+          <div class="date">
+            ${message.created_at}
+          </div>
         </div>
-        <div class="date">
-          ${message.created_at}
-        </div>
-      </div>
-      <div class="message">
-        <p class="lower-message__content">
-          ${message.content}
-        </p>
-      </div>`      
-     return html;
+        <div class="message-detail">
+          <p class="lower-message__content">
+            ${message.content}
+          </p>
+        </div>`      
+      return html;
    };
  }
+
 $('#new_message').on('submit', function(e){
  e.preventDefault();
  var formData = new FormData(this);
@@ -56,6 +60,33 @@ $('#new_message').on('submit', function(e){
   })
   .fail(function() {
     alert("メッセージ送信に失敗しました");
-}); 
+  }); 
 })
+
+  var reloadMessages = function() {
+  var last_message_id = $('.message:last').data("message-id");
+  $.ajax({
+    url: "api/messages",
+    type: 'get',
+    dataType: 'json',
+    data: {id: last_message_id}
+  })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.chat-main__message-list').append(insertHTML);
+        $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+}
+
+if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+  setInterval(reloadMessages, 7000);
+}
 });

--- a/app/assets/stylesheets/modules/_chat-main.scss
+++ b/app/assets/stylesheets/modules/_chat-main.scss
@@ -102,7 +102,7 @@ $section-color:#38aef0;
             font-size: 12px;
           }
         }
-        .message{
+        .message-detail{
           width: 100%;
           margin-top:12px;
           margin-left: 20px;

--- a/app/assets/stylesheets/modules/_side-bar.scss
+++ b/app/assets/stylesheets/modules/_side-bar.scss
@@ -77,6 +77,7 @@
           left:20px;
           font-size:11px;
           margin-top:5px;
+          margin-left: 20px;
         }
       }    
     }

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,2 +1,3 @@
 .wrapper
   = render "side-bar"
+

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,6 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+#idもデータとして渡す
+json.id @message.id

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -19,16 +19,20 @@
 
     .chat-main__message-list
       - @messages.each do |message|
-        .upper
-          .sender
-            = message.user.name
-          .date
-            = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+        .message{data: {message: {id: message.id}}}
+        
+          .upper
+          
+            .sender
+              = message.user.name
+            .date
+              = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 
-        .message
-          - if message.content.present?
-            = message.content
-          = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+          .message-detail
+            - if message.content.present?
+              = message.content
+            = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+
 
     .chat-main__message-form
       .form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
what
chatspace投稿機能において下記を実装した。
・2画面同時に開き、両画面ともメッセージ一覧が自動更新される。
・自動更新時に、画面が最下部までスクロールされる。
・テキスト投稿時/画像投稿時ともに自動更新される

　キャプチャ
　https://gyazo.com/6dc77d93d830a40c204770dc12c52864

why
他ユーザーとのチャットにおいて、両者の画面に、最新チャット内容を（ほぼ）リアルタイムに反映させる機能は必須であるため。